### PR TITLE
Fix #104

### DIFF
--- a/src/main/java/com/mushroom/midnight/common/tile/base/TileEntityMidnightFurnace.java
+++ b/src/main/java/com/mushroom/midnight/common/tile/base/TileEntityMidnightFurnace.java
@@ -1,595 +1,109 @@
 package com.mushroom.midnight.common.tile.base;
 
-import com.mushroom.midnight.common.block.BlockBasic;
+import com.mushroom.midnight.Midnight;
 import com.mushroom.midnight.common.block.BlockMidnightFurnace;
-
 import com.mushroom.midnight.common.registry.ModBlocks;
 import com.mushroom.midnight.common.registry.ModItems;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockFurnace;
-import net.minecraft.block.material.Material;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
-import net.minecraft.inventory.Container;
-import net.minecraft.inventory.ContainerFurnace;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.inventory.ItemStackHelper;
-import net.minecraft.inventory.SlotFurnaceFuel;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemBoat;
-import net.minecraft.item.ItemDoor;
-import net.minecraft.item.ItemHoe;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemSword;
-import net.minecraft.item.ItemTool;
 import net.minecraft.item.crafting.FurnaceRecipes;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
-import net.minecraft.tileentity.TileEntityLockable;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
-import net.minecraft.util.NonNullList;
-import net.minecraft.util.datafix.DataFixer;
-import net.minecraft.util.datafix.FixTypes;
-import net.minecraft.util.datafix.walkers.ItemStackDataLists;
 import net.minecraft.util.math.MathHelper;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-public class TileEntityMidnightFurnace  extends TileEntityLockable implements ITickable, ISidedInventory
-{
-  private static final int[] SLOTS_TOP = new int[] {0};
-  private static final int[] SLOTS_BOTTOM = new int[] {2, 1};
-  private static final int[] SLOTS_SIDES = new int[] {1};
-  /** The ItemStacks that hold the items currently being used in the furnace */
-  private NonNullList<ItemStack> furnaceItemStacks = NonNullList.<ItemStack>withSize(3, ItemStack.EMPTY);
-  /** The number of ticks that the furnace will keep burning */
-  private int furnaceBurnTime;
-  /** The number of ticks that a fresh copy of the currently-burning item would keep the furnace burning for */
-  private int currentItemBurnTime;
-  private int cookTime;
-  private int totalCookTime;
-  private String furnaceCustomName;
-
-  /**
-   * Returns the number of slots in the inventory.
-   */
-  @Override
-  public int getSizeInventory()
-  {
-    return this.furnaceItemStacks.size();
-  }
-  @Override
-  public boolean isEmpty()
-  {
-    for (ItemStack itemstack : this.furnaceItemStacks)
-    {
-      if (!itemstack.isEmpty())
-      {
-        return false;
-      }
+@Mod.EventBusSubscriber(modid = Midnight.MODID)
+public class TileEntityMidnightFurnace extends TileEntityFurnace {
+    
+    @Override
+    public String getName() {
+        return hasCustomName() ? furnaceCustomName : "tile.midnight.midnight_furnace.name";
     }
 
-    return true;
-  }
-
-  /**
-   * Returns the stack in the given slot.
-   */
-  @Override
-  public ItemStack getStackInSlot(int index)
-  {
-    return this.furnaceItemStacks.get(index);
-  }
-
-  /**
-   * Removes up to a specified number of items from an inventory slot and returns them in a new stack.
-   */
-  @Override
-  public ItemStack decrStackSize(int index, int count)
-  {
-    return ItemStackHelper.getAndSplit(this.furnaceItemStacks, index, count);
-  }
-
-  /**
-   * Removes a stack from the given slot and returns it.
-   */
-  @Override
-  public ItemStack removeStackFromSlot(int index)
-  {
-    return ItemStackHelper.getAndRemove(this.furnaceItemStacks, index);
-  }
-
-  /**
-   * Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
-   */
-  @Override
-  public void setInventorySlotContents(int index, ItemStack stack)
-  {
-    ItemStack itemstack = this.furnaceItemStacks.get(index);
-    boolean flag = !stack.isEmpty() && stack.isItemEqual(itemstack) && ItemStack.areItemStackTagsEqual(stack, itemstack);
-    this.furnaceItemStacks.set(index, stack);
-
-    if (stack.getCount() > this.getInventoryStackLimit())
-    {
-      stack.setCount(this.getInventoryStackLimit());
+    @SubscribeEvent
+    public static void onFuelBurnTime(FurnaceFuelBurnTimeEvent event) {
+        Item item = event.getItemStack().getItem();
+        if (item == Item.getItemFromBlock(ModBlocks.SHADOWROOT_SLAB) || item == Item.getItemFromBlock(ModBlocks.DARK_WILLOW_SLAB) || item == Item.getItemFromBlock(ModBlocks.DEAD_WOOD_SLAB)) {
+            event.setBurnTime(150);
+        } else if (item == ModItems.DARK_STICK) {
+            event.setBurnTime(100);
+        } else if (item == ModItems.DARK_PEARL) {
+            event.setBurnTime(1600);
+        } else if (event.getItemStack().getItem() == Item.getItemFromBlock(ModBlocks.DARK_PEARL_BLOCK)) {
+            event.setBurnTime(16000);
+        }
     }
 
-    if (index == 0 && !flag)
-    {
-      this.totalCookTime = this.getCookTime(stack);
-      this.cookTime = 0;
-      this.markDirty();
-    }
-  }
+    @Override
+    public void update() {
+        boolean flag = isBurning();
+        boolean flag1 = false;
+        if (isBurning()) {
+            --furnaceBurnTime;
+        }
+        if (!world.isRemote) {
+            ItemStack itemstack = furnaceItemStacks.get(1);
+            if (isBurning() || !itemstack.isEmpty() && !(furnaceItemStacks.get(0)).isEmpty()) {
+                if (!isBurning() && canSmelt()) {
+                    furnaceBurnTime = getItemBurnTime(itemstack);
+                    currentItemBurnTime = furnaceBurnTime;
+                    if (isBurning()) {
+                        flag1 = true;
+                        if (!itemstack.isEmpty()) {
+                            Item item = itemstack.getItem();
+                            itemstack.shrink(1);
+                            if (itemstack.isEmpty()) {
+                                ItemStack item1 = item.getContainerItem(itemstack);
+                                furnaceItemStacks.set(1, item1);
+                            }
+                        }
+                    }
+                }
+                if (isBurning() && canSmelt()) {
+                    ++cookTime;
 
-  @Override
-  public String getName()
-  {
-    return this.hasCustomName() ? this.furnaceCustomName : "container.furnace";
-  }
-  @Override
-  public boolean hasCustomName()
-  {
-    return this.furnaceCustomName != null && !this.furnaceCustomName.isEmpty();
-  }
-
-  public void setCustomInventoryName(String p_145951_1_)
-  {
-    this.furnaceCustomName = p_145951_1_;
-  }
-
-  public static void registerFixesFurnace(DataFixer fixer)
-  {
-    fixer.registerWalker(FixTypes.BLOCK_ENTITY, new ItemStackDataLists(TileEntityFurnace.class, new String[] {"Items"}));
-  }
-  @Override
-  public void readFromNBT(NBTTagCompound compound)
-  {
-    super.readFromNBT(compound);
-    this.furnaceItemStacks = NonNullList.<ItemStack>withSize(this.getSizeInventory(), ItemStack.EMPTY);
-    ItemStackHelper.loadAllItems(compound, this.furnaceItemStacks);
-    this.furnaceBurnTime = compound.getInteger("BurnTime");
-    this.cookTime = compound.getInteger("CookTime");
-    this.totalCookTime = compound.getInteger("CookTimeTotal");
-    this.currentItemBurnTime = getItemBurnTime(this.furnaceItemStacks.get(1));
-
-    if (compound.hasKey("CustomName", 8))
-    {
-      this.furnaceCustomName = compound.getString("CustomName");
-    }
-  }
-
-  @Override
-  public NBTTagCompound writeToNBT(NBTTagCompound compound)
-  {
-    super.writeToNBT(compound);
-    compound.setInteger("BurnTime", (short)this.furnaceBurnTime);
-    compound.setInteger("CookTime", (short)this.cookTime);
-    compound.setInteger("CookTimeTotal", (short)this.totalCookTime);
-    ItemStackHelper.saveAllItems(compound, this.furnaceItemStacks);
-
-    if (this.hasCustomName())
-    {
-      compound.setString("CustomName", this.furnaceCustomName);
-    }
-
-    return compound;
-  }
-
-  /**
-   * Returns the maximum stack size for a inventory slot. Seems to always be 64, possibly will be extended.
-   */
-  @Override
-  public int getInventoryStackLimit()
-  {
-    return 64;
-  }
-
-  /**
-   * Furnace isBurning
-   */
-
-  public boolean isBurning()
-  {
-    return this.furnaceBurnTime > 0;
-  }
-
-  @SideOnly(Side.CLIENT)
-  public static boolean isBurning(IInventory inventory)
-  {
-    return inventory.getField(0) > 0;
-  }
-
-  /**
-   * Like the old updateEntity(), except more generic.
-   */
-  @Override
-  public void update()
-  {
-    boolean flag = this.isBurning();
-    boolean flag1 = false;
-
-    if (this.isBurning())
-    {
-      --this.furnaceBurnTime;
-    }
-
-    if (!this.world.isRemote)
-    {
-      ItemStack itemstack = this.furnaceItemStacks.get(1);
-
-      if (this.isBurning() || !itemstack.isEmpty() && !((ItemStack)this.furnaceItemStacks.get(0)).isEmpty())
-      {
-        if (!this.isBurning() && this.canSmelt())
-        {
-          this.furnaceBurnTime = getItemBurnTime(itemstack);
-          this.currentItemBurnTime = this.furnaceBurnTime;
-
-          if (this.isBurning())
-          {
-            flag1 = true;
-
-            if (!itemstack.isEmpty())
-            {
-              Item item = itemstack.getItem();
-              itemstack.shrink(1);
-
-              if (itemstack.isEmpty())
-              {
-                ItemStack item1 = item.getContainerItem(itemstack);
-                this.furnaceItemStacks.set(1, item1);
-              }
+                    if (cookTime == totalCookTime) {
+                        cookTime = 0;
+                        totalCookTime = getCookTime(furnaceItemStacks.get(0));
+                        smeltItem();
+                        flag1 = true;
+                    }
+                } else {
+                    cookTime = 0;
+                }
+            } else if (!isBurning() && cookTime > 0) {
+                cookTime = MathHelper.clamp(cookTime - 2, 0, totalCookTime);
             }
-          }
+            if (flag != isBurning()) {
+                flag1 = true;
+                BlockMidnightFurnace.setState(isBurning(), world, pos);
+            }
         }
-
-        if (this.isBurning() && this.canSmelt())
-        {
-          ++this.cookTime;
-
-          if (this.cookTime == this.totalCookTime)
-          {
-            this.cookTime = 0;
-            this.totalCookTime = this.getCookTime(this.furnaceItemStacks.get(0));
-            this.smeltItem();
-            flag1 = true;
-          }
+        if (flag1) {
+            markDirty();
         }
-        else
-        {
-          this.cookTime = 0;
+    }
+
+    private boolean canSmelt() {
+        if ((furnaceItemStacks.get(0)).isEmpty()) {
+            return false;
+        } else {
+            ItemStack itemstack = FurnaceRecipes.instance().getSmeltingResult(furnaceItemStacks.get(0));
+            if (itemstack.isEmpty()) {
+                return false;
+            } else {
+                ItemStack itemstack1 = furnaceItemStacks.get(2);
+                if (itemstack1.isEmpty()) {
+                    return true;
+                } else if (!itemstack1.isItemEqual(itemstack)) {
+                    return false;
+                } else if (itemstack1.getCount() + itemstack.getCount() <= getInventoryStackLimit() && itemstack1.getCount() + itemstack.getCount() <= itemstack1.getMaxStackSize()) { // Forge fix: make furnace respect stack sizes in furnace recipes
+                    return true;
+                } else {
+                    return itemstack1.getCount() + itemstack.getCount() <= itemstack.getMaxStackSize(); // Forge fix: make furnace respect stack sizes in furnace recipes
+                }
+            }
         }
-      }
-      else if (!this.isBurning() && this.cookTime > 0)
-      {
-        this.cookTime = MathHelper.clamp(this.cookTime - 2, 0, this.totalCookTime);
-      }
-
-      if (flag != this.isBurning())
-      {
-        flag1 = true;
-        BlockMidnightFurnace.setState(this.isBurning(), this.world, this.pos);
-      }
     }
-
-    if (flag1)
-    {
-      this.markDirty();
-    }
-  }
-
-  public int getCookTime(ItemStack stack)
-  {
-    return 200;
-  }
-
-  /**
-   * Returns true if the furnace can smelt an item, i.e. has a source item, destination stack isn't full, etc.
-   */
-  private boolean canSmelt()
-  {
-    if (((ItemStack)this.furnaceItemStacks.get(0)).isEmpty())
-    {
-      return false;
-    }
-    else
-    {
-      ItemStack itemstack = FurnaceRecipes.instance().getSmeltingResult(this.furnaceItemStacks.get(0));
-
-      if (itemstack.isEmpty())
-      {
-        return false;
-      }
-      else
-      {
-        ItemStack itemstack1 = this.furnaceItemStacks.get(2);
-
-        if (itemstack1.isEmpty())
-        {
-          return true;
-        }
-        else if (!itemstack1.isItemEqual(itemstack))
-        {
-          return false;
-        }
-        else if (itemstack1.getCount() + itemstack.getCount() <= this.getInventoryStackLimit() && itemstack1.getCount() + itemstack.getCount() <= itemstack1.getMaxStackSize())  // Forge fix: make furnace respect stack sizes in furnace recipes
-        {
-          return true;
-        }
-        else
-        {
-          return itemstack1.getCount() + itemstack.getCount() <= itemstack.getMaxStackSize(); // Forge fix: make furnace respect stack sizes in furnace recipes
-        }
-      }
-    }
-  }
-
-  /**
-   * Turn one item from the furnace source stack into the appropriate smelted item in the furnace result stack
-   */
-  public void smeltItem()
-  {
-    if (this.canSmelt())
-    {
-      ItemStack itemstack = this.furnaceItemStacks.get(0);
-      ItemStack itemstack1 = FurnaceRecipes.instance().getSmeltingResult(itemstack);
-      ItemStack itemstack2 = this.furnaceItemStacks.get(2);
-
-      if (itemstack2.isEmpty())
-      {
-        this.furnaceItemStacks.set(2, itemstack1.copy());
-      }
-      else if (itemstack2.getItem() == itemstack1.getItem())
-      {
-        itemstack2.grow(itemstack1.getCount());
-      }
-
-      if (itemstack.getItem() == Item.getItemFromBlock(Blocks.SPONGE) && itemstack.getMetadata() == 1 && !((ItemStack)this.furnaceItemStacks.get(1)).isEmpty() && ((ItemStack)this.furnaceItemStacks.get(1)).getItem() == Items.BUCKET)
-      {
-        this.furnaceItemStacks.set(1, new ItemStack(Items.WATER_BUCKET));
-      }
-
-      itemstack.shrink(1);
-    }
-  }
-
-  /**
-   * Returns the number of ticks that the supplied fuel item will keep the furnace burning, or 0 if the item isn't
-   * fuel
-   */
-  public static int getItemBurnTime(ItemStack stack)
-  {
-    if (stack.isEmpty())
-    {
-      return 0;
-    }
-    else
-    {
-      int burnTime = net.minecraftforge.event.ForgeEventFactory.getItemBurnTime(stack);
-      if (burnTime >= 0) return burnTime;
-      Item item = stack.getItem();
-
-      if (item == Item.getItemFromBlock(ModBlocks.SHADOWROOT_SLAB))
-      {
-        return 150;
-      }
-      if (item == Item.getItemFromBlock(ModBlocks.DARK_WILLOW_SLAB))
-      {
-        return 150;
-      }
-      if (item == Item.getItemFromBlock(ModBlocks.DEAD_WOOD_SLAB))
-        {
-            return 150;
-        }
-      else if (Block.getBlockFromItem(item).getDefaultState().getMaterial() == Material.WOOD)
-      {
-        return 300;
-      }
-      else if (item == Item.getItemFromBlock(ModBlocks.DARK_PEARL_BLOCK))
-      {
-        return 16000;
-      }
-      else if (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).getToolMaterialName()))
-      {
-        return 200;
-      }
-      else if (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).getToolMaterialName()))
-      {
-        return 200;
-      }
-      else if (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).getMaterialName()))
-      {
-        return 200;
-      }
-      else if (item == ModItems.DARK_STICK)
-      {
-        return 100;
-      }
-      else if (item == ModItems.DARK_PEARL)
-        {
-          return 1600;
-        }
-          else
-          {
-            return item instanceof ItemBoat ? 400 : 0;
-          }
-        }
-  }
-
-  public static boolean isItemFuel(ItemStack stack)
-  {
-    return getItemBurnTime(stack) > 0;
-  }
-
-  /**
-   * Don't rename this method to canInteractWith due to conflicts with Container
-   */
-  @Override
-  public boolean isUsableByPlayer(EntityPlayer player)
-  {
-    if (this.world.getTileEntity(this.pos) != this)
-    {
-      return false;
-    }
-    else
-    {
-      return player.getDistanceSq((double)this.pos.getX() + 0.5D, (double)this.pos.getY() + 0.5D, (double)this.pos.getZ() + 0.5D) <= 64.0D;
-    }
-  }
-
-  @Override
-  public void openInventory(EntityPlayer player)
-  {
-  }
-  @Override
-  public void closeInventory(EntityPlayer player)
-  {
-  }
-
-  /**
-   * Returns true if automation is allowed to insert the given stack (ignoring stack size) into the given slot. For
-   * guis use Slot.isItemValid
-   */
-  @Override
-  public boolean isItemValidForSlot(int index, ItemStack stack)
-  {
-    if (index == 2)
-    {
-      return false;
-    }
-    else if (index != 1)
-    {
-      return true;
-    }
-    else
-    {
-      ItemStack itemstack = this.furnaceItemStacks.get(1);
-      return isItemFuel(stack) || SlotFurnaceFuel.isBucket(stack) && itemstack.getItem() != Items.BUCKET;
-    }
-  }
-
-  @Override
-  public int[] getSlotsForFace(EnumFacing side)
-  {
-    if (side == EnumFacing.DOWN)
-    {
-      return SLOTS_BOTTOM;
-    }
-    else
-    {
-      return side == EnumFacing.UP ? SLOTS_TOP : SLOTS_SIDES;
-    }
-  }
-
-  /**
-   * Returns true if automation can insert the given item in the given slot from the given side.
-   */
-  @Override
-  public boolean canInsertItem(int index, ItemStack itemStackIn, EnumFacing direction)
-  {
-    return this.isItemValidForSlot(index, itemStackIn);
-  }
-
-  /**
-   * Returns true if automation can extract the given item in the given slot from the given side.
-   */
-  @Override
-  public boolean canExtractItem(int index, ItemStack stack, EnumFacing direction)
-  {
-    if (direction == EnumFacing.DOWN && index == 1)
-    {
-      Item item = stack.getItem();
-
-      if (item != Items.WATER_BUCKET && item != Items.BUCKET)
-      {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  @Override
-  public String getGuiID()
-  {
-    return "minecraft:furnace";
-  }
-
-  @Override
-  public Container createContainer(InventoryPlayer playerInventory, EntityPlayer playerIn)
-  {
-    return new ContainerFurnace(playerInventory, this);
-  }
-
-  @Override
-  public int getField(int id)
-  {
-    switch (id)
-    {
-    case 0:
-      return this.furnaceBurnTime;
-    case 1:
-      return this.currentItemBurnTime;
-    case 2:
-      return this.cookTime;
-    case 3:
-      return this.totalCookTime;
-    default:
-      return 0;
-    }
-  }
-
-  @Override
-  public void setField(int id, int value)
-  {
-    switch (id)
-    {
-    case 0:
-      this.furnaceBurnTime = value;
-      break;
-    case 1:
-      this.currentItemBurnTime = value;
-      break;
-    case 2:
-      this.cookTime = value;
-      break;
-    case 3:
-      this.totalCookTime = value;
-    }
-  }
-
-  @Override
-  public int getFieldCount()
-  {
-    return 4;
-  }
-
-  @Override
-  public void clear()
-  {
-    this.furnaceItemStacks.clear();
-  }
-
-  net.minecraftforge.items.IItemHandler handlerTop = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.UP);
-  net.minecraftforge.items.IItemHandler handlerBottom = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.DOWN);
-  net.minecraftforge.items.IItemHandler handlerSide = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.WEST);
-
-  @SuppressWarnings("unchecked")
-  @Override
-  @javax.annotation.Nullable
-  public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @javax.annotation.Nullable net.minecraft.util.EnumFacing facing)
-  {
-    if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-      if (facing == EnumFacing.DOWN)
-        return (T) handlerBottom;
-      else if (facing == EnumFacing.UP)
-        return (T) handlerTop;
-      else
-        return (T) handlerSide;
-    return super.getCapability(capability, facing);
-  }
 }

--- a/src/main/java/com/mushroom/midnight/common/tile/base/TileEntityShadowrootChest.java
+++ b/src/main/java/com/mushroom/midnight/common/tile/base/TileEntityShadowrootChest.java
@@ -4,4 +4,8 @@ import net.minecraft.tileentity.TileEntityChest;
 
 public class TileEntityShadowrootChest extends TileEntityChest {
 
+    @Override
+    public String getName() {
+        return hasCustomName() ? customName : "tile.midnight.shadowroot_chest.name";
+    }
 }

--- a/src/main/java/com/mushroom/midnight/common/tile/base/package-info.java
+++ b/src/main/java/com/mushroom/midnight/common/tile/base/package-info.java
@@ -1,0 +1,3 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@mcp.MethodsReturnNonnullByDefault
+package com.mushroom.midnight.common.tile.base;

--- a/src/main/resources/META-INF/midnight_at.cfg
+++ b/src/main/resources/META-INF/midnight_at.cfg
@@ -2,4 +2,5 @@ public net.minecraft.world.gen.structure.template.Template field_186270_a # bloc
 public-f net.minecraft.entity.EntityLiving field_70749_g # lookHelper
 
 public-f net.minecraft.world.biome.Biome func_185359_l()Ljava/lang/String; # getBiomeName
-public-f net.minecraft.pathfinding.WalkNodeProcessor func_186332_a(IIIIDLnet/minecraft/util/EnumFacing;)Lnet/minecraft/pathfinding/PathPoint; # getSafePoint
+protected net.minecraft.pathfinding.WalkNodeProcessor func_186332_a(IIIIDLnet/minecraft/util/EnumFacing;)Lnet/minecraft/pathfinding/PathPoint; # getSafePoint
+protected net.minecraft.tileentity.TileEntityFurnace * # The Furnace


### PR DESCRIPTION
- display the correct name in the gui for the furnace and the chest
- allows to use dark pearl as fuel in the furnace (related to the ContainerFurnace that uses a custom slot for fuel and the dark pearl is in material iron)