### PR TITLE
config option to hide the dark overlay & fix #157

### DIFF
--- a/src/main/java/com/mushroom/midnight/client/ClientEventHandler.java
+++ b/src/main/java/com/mushroom/midnight/client/ClientEventHandler.java
@@ -239,11 +239,10 @@ public class ClientEventHandler {
     @SubscribeEvent(priority=EventPriority.LOWEST)
     public static void onRenderVignetteOverLay(RenderGameOverlayEvent.Pre event) {
         if (MidnightConfig.hideDarkOverlayInMidnight && event.getType() == RenderGameOverlayEvent.ElementType.VIGNETTE) {
-            Minecraft mc = Minecraft.getMinecraft();
-            if (Helper.isMidnightDimension(mc.world)) {
-                WorldBorder worldborder = mc.world.getWorldBorder();
+            if (Helper.isMidnightDimension(MC.world)) {
+                WorldBorder worldborder = MC.world.getWorldBorder();
                 float distWarn = Math.max(worldborder.getWarningDistance(), (float) Math.min(worldborder.getResizeSpeed() * worldborder.getWarningTime() * 1000d, Math.abs(worldborder.getTargetSize() - worldborder.getDiameter())));
-                if (worldborder.getClosestDistance(mc.player) >= distWarn) {
+                if (worldborder.getClosestDistance(MC.player) >= distWarn) {
                     event.setCanceled(true);
                 }
             }

--- a/src/main/java/com/mushroom/midnight/client/ClientEventHandler.java
+++ b/src/main/java/com/mushroom/midnight/client/ClientEventHandler.java
@@ -238,7 +238,7 @@ public class ClientEventHandler {
 
     @SubscribeEvent(priority=EventPriority.LOWEST)
     public static void onRenderVignetteOverLay(RenderGameOverlayEvent.Pre event) {
-        if (MidnightConfig.hideDarkOverlayInMidnight && event.getType() == RenderGameOverlayEvent.ElementType.VIGNETTE) {
+        if (MidnightConfig.hideVignetteEffect && event.getType() == RenderGameOverlayEvent.ElementType.VIGNETTE) {
             if (Helper.isMidnightDimension(MC.world)) {
                 WorldBorder worldborder = MC.world.getWorldBorder();
                 float distWarn = Math.max(worldborder.getWarningDistance(), (float) Math.min(worldborder.getResizeSpeed() * worldborder.getWarningTime() * 1000d, Math.abs(worldborder.getTargetSize() - worldborder.getDiameter())));

--- a/src/main/java/com/mushroom/midnight/client/ClientEventHandler.java
+++ b/src/main/java/com/mushroom/midnight/client/ClientEventHandler.java
@@ -4,6 +4,7 @@ import com.mushroom.midnight.Midnight;
 import com.mushroom.midnight.client.particle.MidnightParticles;
 import com.mushroom.midnight.client.sound.IdleRiftSound;
 import com.mushroom.midnight.common.capability.RifterCapturedCapability;
+import com.mushroom.midnight.common.config.MidnightConfig;
 import com.mushroom.midnight.common.entity.EntityRift;
 import com.mushroom.midnight.common.helper.Helper;
 import com.mushroom.midnight.common.registry.ModBiomes;
@@ -29,7 +30,9 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.border.WorldBorder;
 import net.minecraftforge.client.event.EntityViewRenderEvent;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -231,5 +234,19 @@ public class ClientEventHandler {
     private static boolean isMusicSound() {
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         return Arrays.stream(stackTrace).anyMatch(e -> e.getClassName().equals(MusicTicker.class.getName()));
+    }
+
+    @SubscribeEvent(priority=EventPriority.LOWEST)
+    public static void onRenderVignetteOverLay(RenderGameOverlayEvent.Pre event) {
+        if (MidnightConfig.hideDarkOverlayInMidnight && event.getType() == RenderGameOverlayEvent.ElementType.VIGNETTE) {
+            Minecraft mc = Minecraft.getMinecraft();
+            if (Helper.isMidnightDimension(mc.world)) {
+                WorldBorder worldborder = mc.world.getWorldBorder();
+                float distWarn = Math.max(worldborder.getWarningDistance(), (float) Math.min(worldborder.getResizeSpeed() * worldborder.getWarningTime() * 1000d, Math.abs(worldborder.getTargetSize() - worldborder.getDiameter())));
+                if (worldborder.getClosestDistance(mc.player) >= distWarn) {
+                    event.setCanceled(true);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/mushroom/midnight/common/config/MidnightConfig.java
+++ b/src/main/java/com/mushroom/midnight/common/config/MidnightConfig.java
@@ -33,6 +33,11 @@ public class MidnightConfig {
     @Config.Comment("If true, players will be allowed to respawn in Midnight.")
     public static boolean canRespawnInMidnight = false;
 
+    @Config.Name("hide_dark_overlay_in_midnight")
+    @Config.LangKey("config.midnight.hide_dark_overlay_in_midnight")
+    @Config.Comment("If true, the circular overlay appearing in dark area will be hidden in midnight, without the need to disable the fancy graphics.")
+    public static boolean hideDarkOverlayInMidnight = false;
+
     @SubscribeEvent
     public static void configChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
         if (event.getModID().equals(Midnight.MODID)) {

--- a/src/main/java/com/mushroom/midnight/common/config/MidnightConfig.java
+++ b/src/main/java/com/mushroom/midnight/common/config/MidnightConfig.java
@@ -33,10 +33,10 @@ public class MidnightConfig {
     @Config.Comment("If true, players will be allowed to respawn in Midnight.")
     public static boolean canRespawnInMidnight = false;
 
-    @Config.Name("hide_dark_overlay_in_midnight")
-    @Config.LangKey("config.midnight.hide_dark_overlay_in_midnight")
-    @Config.Comment("If true, the circular overlay appearing in dark area will be hidden in midnight, without the need to disable the fancy graphics.")
-    public static boolean hideDarkOverlayInMidnight = false;
+    @Config.Name("hide_vignette_effect")
+    @Config.LangKey("config.midnight.hide_vignette_effect")
+    @Config.Comment("Hides the vignette effect in the dark areas of Midnight.")
+    public static boolean hideVignetteEffect = false;
 
     @SubscribeEvent
     public static void configChanged(ConfigChangedEvent.OnConfigChangedEvent event) {

--- a/src/main/java/com/mushroom/midnight/common/entity/EntityRift.java
+++ b/src/main/java/com/mushroom/midnight/common/entity/EntityRift.java
@@ -205,9 +205,8 @@ public class EntityRift extends Entity implements IEntityAdditionalSpawnData {
     private void teleportEntities() {
         AxisAlignedBB bounds = this.getEntityBoundingBox().grow(-0.4, 0.0, -0.4);
         DimensionType endpointDimension = this.getEndpointDimension();
-
         List<Entity> entities = this.world.getEntitiesInAABBexcluding(this, bounds, entity -> {
-            if (entity.isRiding()) {
+            if (entity.isRiding() || (entity instanceof EntityPlayer && ((EntityPlayer)entity).isSpectator())) {
                 return false;
             }
             RiftCooldownCapability cooldown = entity.getCapability(Midnight.riftCooldownCap, null);

--- a/src/main/java/com/mushroom/midnight/common/world/MidnightWorldProvider.java
+++ b/src/main/java/com/mushroom/midnight/common/world/MidnightWorldProvider.java
@@ -171,10 +171,13 @@ public class MidnightWorldProvider extends WorldProvider {
     @Nullable
     @SideOnly(Side.CLIENT)
     public IRenderHandler getCloudRenderer() {
-        return new IRenderHandler() {
-            @Override
-            public void render(float partialTicks, WorldClient world, Minecraft mc) {
-            }
-        };
+        if (super.getCloudRenderer() == null) {
+            setCloudRenderer(new IRenderHandler() {
+                @Override
+                public void render(float partialTicks, WorldClient world, Minecraft mc) {
+                }
+            });
+        }
+        return super.getCloudRenderer();
     }
 }

--- a/src/main/java/com/mushroom/midnight/common/world/MidnightWorldProvider.java
+++ b/src/main/java/com/mushroom/midnight/common/world/MidnightWorldProvider.java
@@ -2,8 +2,6 @@ package com.mushroom.midnight.common.world;
 
 import com.mushroom.midnight.common.config.MidnightConfig;
 import com.mushroom.midnight.common.registry.ModDimensions;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.player.EntityPlayer;
@@ -15,11 +13,9 @@ import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.gen.IChunkGenerator;
-import net.minecraftforge.client.IRenderHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.Random;
 
@@ -165,19 +161,5 @@ public class MidnightWorldProvider extends WorldProvider {
     @Override
     public boolean shouldClientCheckLighting() {
         return true;
-    }
-
-    @Override
-    @Nullable
-    @SideOnly(Side.CLIENT)
-    public IRenderHandler getCloudRenderer() {
-        if (super.getCloudRenderer() == null) {
-            setCloudRenderer(new IRenderHandler() {
-                @Override
-                public void render(float partialTicks, WorldClient world, Minecraft mc) {
-                }
-            });
-        }
-        return super.getCloudRenderer();
     }
 }

--- a/src/main/resources/assets/midnight/lang/en_us.lang
+++ b/src/main/resources/assets/midnight/lang/en_us.lang
@@ -280,8 +280,8 @@ config.midnight.bladeshroom_damage_chance.tooltip=The chance to take damage when
 config.midnight.can_respawn_in_midnight=Allow to respawn in Midnight
 config.midnight.can_respawn_in_midnight.tooltip=If true, players will be allowed to respawn in Midnight.
 
-config.midnight.hide_dark_overlay_in_midnight=Hide the dark overlay in Midnight
-config.midnight.hide_dark_overlay_in_midnight.tooltip=If true, the circular overlay appearing in dark areas will be hidden in Midnight, without the need to disable the fancy graphics.
+config.midnight.hide_vignette_effect=Hides the vignette effect
+config.midnight.hide_vignette_effect.tooltip=Hides the vignette effect in the dark areas of Midnight.
 
 status.midnight.rift_nearby=You may not rest now, there is an evil presence nearby
 status.midnight.snapped=The fish snapped at you

--- a/src/main/resources/assets/midnight/lang/en_us.lang
+++ b/src/main/resources/assets/midnight/lang/en_us.lang
@@ -269,16 +269,19 @@ entity.midnight.nova.name=Nova
 # Config
 
 config.midnight.midnight_dimension_id=Midnight Dimension ID
-config.midnight.midnight_dimension_id.tooltip=The ID to be used for the Midnight Dimension
+config.midnight.midnight_dimension_id.tooltip=The ID to be used for the Midnight Dimension.
 
 config.midnight.rift_shaders=Rift Shaders
 config.midnight.rift_shaders.tooltip=If true, rifts will be rendered with custom shaders for standard effects. If false, a simpler texture will be rendered.
 
 config.midnight.bladeshroom_damage_chance=Bladeshroom Damage Chance
-config.midnight.bladeshroom_damage_chance.tooltip=The chance to take damage when picking a bladeshroom cap
+config.midnight.bladeshroom_damage_chance.tooltip=The chance to take damage when picking a bladeshroom cap.
 
 config.midnight.can_respawn_in_midnight=Allow to respawn in Midnight
 config.midnight.can_respawn_in_midnight.tooltip=If true, players will be allowed to respawn in Midnight.
+
+config.midnight.hide_dark_overlay_in_midnight=Hide the dark overlay in Midnight
+config.midnight.hide_dark_overlay_in_midnight.tooltip=If true, the circular overlay appearing in dark areas will be hidden in Midnight, without the need to disable the fancy graphics.
 
 status.midnight.rift_nearby=You may not rest now, there is an evil presence nearby
 status.midnight.snapped=The fish snapped at you

--- a/src/main/resources/assets/midnight/lang/fr_fr.lang
+++ b/src/main/resources/assets/midnight/lang/fr_fr.lang
@@ -269,16 +269,19 @@ entity.midnight.nova.name=Nova
 # Config
 
 config.midnight.midnight_dimension_id=ID de la dimension de Minuit
-config.midnight.midnight_dimension_id.tooltip=L'ID qui va être utilisé pour la dimension de Minuit
+config.midnight.midnight_dimension_id.tooltip=L'ID qui va être utilisé pour la dimension de Minuit.
 
 config.midnight.rift_shaders=Ombrages des Failles
 config.midnight.rift_shaders.tooltip=Si vrai, les failles seront affichées avec des ombrages personalisés pour les effets standards. Si faux, une texture plus simple sera utilisée.
 
 config.midnight.bladeshroom_damage_chance=Chance de dégâts des ChampiLames
-config.midnight.bladeshroom_damage_chance.tooltip=La chance de subir des dégâts quand un Chapeau de ChampiLame est ramassé
+config.midnight.bladeshroom_damage_chance.tooltip=La chance de subir des dégâts quand un Chapeau de ChampiLame est ramassé.
 
 config.midnight.can_respawn_in_midnight=Permet de réapparaître dans Minuit
 config.midnight.can_respawn_in_midnight.tooltip=Si vrai, les joueurs seront autorisés à réapparaître dans la dimension de Minuit.
+
+config.midnight.hide_dark_overlay_in_midnight=Cache l'overlay sombre dans Minuit
+config.midnight.hide_dark_overlay_in_midnight.tooltip=Si vrai, l'overlay circulaire apparaissant dans les zones sombres sera caché dans Minuit, sans avoir besoin de désactiver les graphismes détaillés.
 
 status.midnight.rift_nearby=Vous ne pouvez pas rester ici pour l'instant, il y a une présence démoniaque à proximitée
 status.midnight.snapped=Le poisson t'a baffé

--- a/src/main/resources/assets/midnight/lang/fr_fr.lang
+++ b/src/main/resources/assets/midnight/lang/fr_fr.lang
@@ -280,8 +280,8 @@ config.midnight.bladeshroom_damage_chance.tooltip=La chance de subir des dégât
 config.midnight.can_respawn_in_midnight=Permet de réapparaître dans Minuit
 config.midnight.can_respawn_in_midnight.tooltip=Si vrai, les joueurs seront autorisés à réapparaître dans la dimension de Minuit.
 
-config.midnight.hide_dark_overlay_in_midnight=Cache l'overlay sombre dans Minuit
-config.midnight.hide_dark_overlay_in_midnight.tooltip=Si vrai, l'overlay circulaire apparaissant dans les zones sombres sera caché dans Minuit, sans avoir besoin de désactiver les graphismes détaillés.
+config.midnight.hide_vignette_effect=Cache l'effet de vignette
+config.midnight.hide_vignette_effect.tooltip=Cache l'effet de vignette dans les zones sombres de Minuit.
 
 status.midnight.rift_nearby=Vous ne pouvez pas rester ici pour l'instant, il y a une présence démoniaque à proximitée
 status.midnight.snapped=Le poisson t'a baffé


### PR DESCRIPTION
It's mainly to have the possibility to remove this overlay that appears all the time in midnight, without disabling the fancy graphics (and keep it working near world border with the warning distance)