### PR TITLE
Force the line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This is done to prevent tons of line-endings change diffs from appearing for commits from people using different operating systems/IDE settings.