### PR TITLE
Let fungi hat support silk touching

### DIFF
--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/src/generated/resources/data/midnight/loot_tables/blocks/bogshroom_hat.json
+++ b/src/generated/resources/data/midnight/loot_tables/blocks/bogshroom_hat.json
@@ -11,6 +11,25 @@
               "type": "minecraft:item",
               "conditions": [
                 {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "midnight:bogshroom_hat"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
                   "condition": "minecraft:random_chance",
                   "chance": 0.5
                 }
@@ -23,12 +42,12 @@
             }
           ]
         }
-      ],
-      "functions": [
-        {
-          "function": "minecraft:explosion_decay"
-        }
       ]
+    }
+  ],
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
     }
   ]
 }

--- a/src/generated/resources/data/midnight/loot_tables/blocks/dewshroom_hat.json
+++ b/src/generated/resources/data/midnight/loot_tables/blocks/dewshroom_hat.json
@@ -11,6 +11,25 @@
               "type": "minecraft:item",
               "conditions": [
                 {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "midnight:dewshroom_hat"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
                   "condition": "minecraft:random_chance",
                   "chance": 0.5
                 }
@@ -23,12 +42,12 @@
             }
           ]
         }
-      ],
-      "functions": [
-        {
-          "function": "minecraft:explosion_decay"
-        }
       ]
+    }
+  ],
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
     }
   ]
 }

--- a/src/generated/resources/data/midnight/loot_tables/blocks/nightshroom_hat.json
+++ b/src/generated/resources/data/midnight/loot_tables/blocks/nightshroom_hat.json
@@ -11,6 +11,25 @@
               "type": "minecraft:item",
               "conditions": [
                 {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "midnight:nightshroom_hat"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
                   "condition": "minecraft:random_chance",
                   "chance": 0.5
                 }
@@ -23,12 +42,12 @@
             }
           ]
         }
-      ],
-      "functions": [
-        {
-          "function": "minecraft:explosion_decay"
-        }
       ]
+    }
+  ],
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
     }
   ]
 }

--- a/src/generated/resources/data/midnight/loot_tables/blocks/viridshroom_hat.json
+++ b/src/generated/resources/data/midnight/loot_tables/blocks/viridshroom_hat.json
@@ -11,6 +11,25 @@
               "type": "minecraft:item",
               "conditions": [
                 {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "midnight:viridshroom_hat"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
                   "condition": "minecraft:random_chance",
                   "chance": 0.5
                 }
@@ -23,12 +42,12 @@
             }
           ]
         }
-      ],
-      "functions": [
-        {
-          "function": "minecraft:explosion_decay"
-        }
       ]
+    }
+  ],
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
     }
   ]
 }

--- a/src/main/java/com/mushroom/midnight/common/data/loot/MidnightBlockLootProvider.java
+++ b/src/main/java/com/mushroom/midnight/common/data/loot/MidnightBlockLootProvider.java
@@ -34,6 +34,7 @@ import net.minecraft.world.storage.loot.functions.ApplyBonus;
 import net.minecraft.world.storage.loot.functions.CopyName;
 import net.minecraft.world.storage.loot.functions.ExplosionDecay;
 import net.minecraft.world.storage.loot.functions.SetCount;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -386,19 +387,19 @@ public final class MidnightBlockLootProvider extends MidnightLootTableProvider {
                 ));
     }
 
-    private static LootTable.Builder selfOrAlternative(Block block, ILootCondition.IBuilder condition, LootEntry.Builder<?> alternative) {
+    private static LootTable.Builder selfOrAlternatives(Block block, ILootCondition.IBuilder condition, LootEntry.Builder<?>... alternatives) {
         return LootTable.builder().addLootPool(LootPool.builder()
-                .addEntry(ItemLootEntry.builder(block).acceptCondition(condition).func_216080_a(alternative))
+                .addEntry(new AlternativesLootEntry.Builder(ArrayUtils.insert(0, alternatives, ItemLootEntry.builder(block).acceptCondition(condition))))
                 .rolls(ONE)
         );
     }
 
-    private static LootTable.Builder silkTouched(Block block, LootEntry.Builder<?> alternative) {
-        return selfOrAlternative(block, Conditions.HAS_SILK_TOUCH, alternative);
+    private static LootTable.Builder silkTouched(Block block, LootEntry.Builder<?>... alternatives) {
+        return selfOrAlternatives(block, Conditions.HAS_SILK_TOUCH, alternatives);
     }
 
-    private static LootTable.Builder silkOrSheared(Block block, LootEntry.Builder<?> alternative) {
-        return selfOrAlternative(block, Conditions.HAS_SHEARS_OR_SILK_TOUCH, alternative);
+    private static LootTable.Builder silkOrSheared(Block block, LootEntry.Builder<?>... alternatives) {
+        return selfOrAlternatives(block, Conditions.HAS_SHEARS_OR_SILK_TOUCH, alternatives);
     }
 
     private static LootTable.Builder copyName(Block block) {
@@ -461,14 +462,11 @@ public final class MidnightBlockLootProvider extends MidnightLootTableProvider {
     }
 
     private void addFungiHat(Block block, IItemProvider fungi, IItemProvider powder) {
-        LootPool.Builder pool = LootPool.builder()
-                .addEntry(AlternativesLootEntry.func_216149_a(
+        this.add(block, explosionDecay(silkTouched(
+                        block,
                         ItemLootEntry.builder(fungi).acceptCondition(RandomChance.builder(0.5F)),
                         ItemLootEntry.builder(powder)
-                ))
-                .rolls(ONE);
-
-        this.add(block, LootTable.builder().addLootPool(explosionDecay(pool)));
+        )));
     }
 
     private void addUnstableBush(Block block, IItemProvider fruit) {


### PR DESCRIPTION
To achieve this, I have added support for variable arguments to the `silkTouched` and `silkOrSheared` methods.

Resolves #300 

Note: #306 should be merged alongside with this, since without it, every data file (or just the ones that were changed in this PR, depends on your system) will be regenerated with other line endings.