### PR TITLE
Fix NightStags (and other mobs [nyi]) not spawning

### DIFF
--- a/src/main/java/com/mushroom/midnight/common/entity/creature/NightStagEntity.java
+++ b/src/main/java/com/mushroom/midnight/common/entity/creature/NightStagEntity.java
@@ -59,6 +59,7 @@ import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.IWorld;
+import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.capabilities.Capability;
@@ -202,6 +203,11 @@ public class NightStagEntity extends AnimalEntity {
             return false;
         }
         return super.canSpawn(worldIn, spawnReasonIn);
+    }
+    
+    @Override
+    public float getBlockPathWeight(BlockPos pos, IWorldReader world) {
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
I fixed the spawning issue of Nightstags - they weren't spawning because of the lack of light and vanilla grass blocks.
I still need to look at other mobs but I did not get time for that yet