### PR TITLE
Molten crater bug: unstable miasma blocks don't flow in this structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ If you would like to support our work, consider donating to our [Patreon](https:
 - **Texturers**: [Endergized](https://github.com/Endergy), [Five (Paradiscal)](https://github.com/fivelol), [MCVinnyq](https://github.com/MCVinnyq)
 - **Modelers**: [Cipher_Zero_X](https://github.com/cipherzerox), [MCvinnnyq](https://github.com/MCVinnyq)
 - **Sound Designers**: [Lachney](https://xjon.me)
-- **Contributers and Testers**: [ZombieEnderman5](https://github.com/ZombieEnderman5), [veesus mikhel heir](https://minecraft.curseforge.com/members/veesusmikelheir), 123wdog, [Terenx](https://github.com/Terenx), [KingPhygieBoo](https://gitlab.com/KingPhygieBoo)
+- **Contributors and Testers**: [ZombieEnderman5](https://github.com/ZombieEnderman5), [veesus mikhel heir](https://minecraft.curseforge.com/members/veesusmikelheir), 123wdog, [Terenx](https://github.com/Terenx), [KingPhygieBoo](https://gitlab.com/KingPhygieBoo)

--- a/src/main/java/com/mushroom/midnight/common/world/feature/structure/MoltenCraterStructure.java
+++ b/src/main/java/com/mushroom/midnight/common/world/feature/structure/MoltenCraterStructure.java
@@ -289,6 +289,9 @@ public final class MoltenCraterStructure extends Structure<NoFeatureConfig> {
                             BlockState state = this.selectSurfaceState(random);
                             if (state != null) {
                                 world.setBlockState(mutablePos, state, Constants.BlockFlags.BLOCK_UPDATE);
+                                if( state == MIASMA ) {
+                                    world.getPendingFluidTicks().scheduleTick( mutablePos, MidnightFluids.MIASMA, 0 );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Miasma generated on the edges of molten craters doesn't seem to flow towards the miasma pool within the crater. It instead stays as unstable, not-flowing fluid blocks on the edge until a block is placed next to them.
Edit made on GitHub, haven't tested it...

Also, I changed a spelling mistake in README.md: 'contributers' should be 'contributors' ;)